### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
----
 vgo wayback 
 
 `go get repo...` and `go get -u` updates with the latest available commit.
@@ -13,30 +12,30 @@ dependency successively look for the commit or tag nearest the current
 modules wayback time.
 
 ```
-// https://gist.github.com/davidwalter0/60f41b53732656c5c546cc8b0a739d11
+https://gist.github.com/davidwalter0/60f41b53732656c5c546cc8b0a739d11
 
-// x/vgo: thoughts on selection criteria for non-versioned go repo
+x/vgo: thoughts on selection criteria for non-versioned go repo
 
-// Run git branch version selection for non-vgo versioned repository
-// as if in a wayback machine.
+Run git branch version selection for non-vgo versioned repository
+as if in a wayback machine.
 
-// Use the dependency's commit ctime as the wayback ctime.
-// Commits prior to the wayback ctime in sub-dependencies are eligible.
-// Use the newest commit prior to the wayback ctime.
+Use the dependency's commit ctime as the wayback ctime.
+Commits prior to the wayback ctime in sub-dependencies are eligible.
+Use the newest commit prior to the wayback ctime.
 
-// Rough sketch of wayback idea to find a candidate ctime of a git commit
+Rough sketch of wayback idea to find a candidate ctime of a git commit
 
-// This would need to be integrated into vgo logic and of course
-// non-git vc methods.
+This would need to be integrated into vgo logic and of course
+non-git vc methods.
 
-// Add tooling from go-git examples to remove the external dependency
+Add tooling from go-git examples to remove the external dependency
 
-// Example command line for gopkg.in/src-d/go-git
+Example command line for gopkg.in/src-d/go-git
 
-// Select some arbitrary ctime for the wayback time
+Select some arbitrary ctime for the wayback time
 
-// export ctime='2017-09-04 19:43:36 +0300';
-// vgo run main.go /go/src/gopkg.in/src-d/go-git.v4 "${ctime}"
+export ctime='2017-09-04 19:43:36 +0300';
+vgo run main.go /go/src/gopkg.in/src-d/go-git.v4 "${ctime}"
 ```
 
 

--- a/go.mod
+++ b/go.mod
@@ -1,18 +1,28 @@
 module github.com/davidwalter0/wayback
 
 require (
+	github.com/alcortesm/tgz v0.0.0-20161220082320-9c5fe88206d7
+	github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239
 	github.com/emirpasic/gods v1.9.0
+	github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568
+	github.com/gliderlabs/ssh v0.1.0
+	github.com/google/go-cmp v0.2.0
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99
 	github.com/kevinburke/ssh_config v0.0.0-20180422193403-4fcc689beeab
-	github.com/mitchellh/go-homedir v0.0.0-20161203194507-b8bc1bf76747
+	github.com/mitchellh/go-homedir v0.0.0-20180523094522-3864e76763d9
 	github.com/pelletier/go-buffruneio v0.2.0
+	github.com/pkg/errors v0.8.0
 	github.com/sergi/go-diff v1.0.0
 	github.com/src-d/gcfg v1.3.0
+	github.com/stretchr/objx v0.0.0-20180426105006-a5cfa15c000a
 	github.com/xanzy/ssh-agent v0.0.0-20151215153451-ba9c9e33906f
-	golang.org/x/crypto v0.0.0-20180515001509-1a580b3eff78
-	golang.org/x/net v0.0.0-20180521201818-8e0cdda24ed4
+	golang.org/x/crypto v0.0.0-20180524125353-159ae71589f3
+	golang.org/x/net v0.0.0-20180522190444-9ef9f5bb98a1
+	golang.org/x/sys v0.0.0-20180524135853-04b83988a018
 	golang.org/x/text v0.3.0
+	gopkg.in/check.v1 v1.0.0-20161208181325-20d25e280405
 	gopkg.in/src-d/go-billy.v4 v4.1.1
+	gopkg.in/src-d/go-git-fixtures.v3 v3.1.0
 	gopkg.in/src-d/go-git.v4 v4.4.0
 	gopkg.in/warnings.v0 v0.1.2
 )


### PR DESCRIPTION
vgo wayback 

`go get repo...` and `go get -u` updates with the latest available commit.

How would you find likely versions that go get would find if you were
living in the past, you went wayback, what would be the latest
available at the wayback time?

If you had a wayback machine, you'd set your time to the commit time
of module or tag -- the wayback time of the module, then for each
dependency successively look for the commit or tag nearest the current
modules wayback time.

```
https://gist.github.com/davidwalter0/60f41b53732656c5c546cc8b0a739d11

x/vgo: thoughts on selection criteria for non-versioned go repo

Run git branch version selection for non-vgo versioned repository
as if in a wayback machine.

Use the dependency's commit ctime as the wayback ctime.
Commits prior to the wayback ctime in sub-dependencies are eligible.
Use the newest commit prior to the wayback ctime.

Rough sketch of wayback idea to find a candidate ctime of a git commit

This would need to be integrated into vgo logic and of course
non-git vc methods.

Add tooling from go-git examples to remove the external dependency

Example command line for gopkg.in/src-d/go-git

Select some arbitrary ctime for the wayback time

export ctime='2017-09-04 19:43:36 +0300';
vgo run main.go /go/src/gopkg.in/src-d/go-git.v4 "${ctime}"
```


---

Not to be confused with the phonetically similar *we go wayback*
